### PR TITLE
fix README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ genie download-snapshot [--snapshot <snapshot_id>] -o thingpedia.json
 If you omit the `--snapshot` parameter, the latest content of Thingpedia will be used.
 
 The `--dataset` flag to should point to the primitive templates in ThingTalk dataset syntax.
-See the [Thingpedia documentation[(https://almond.stanford.edu/thingpedia/developers/thingpedia-nl-support.md)
+See the [Thingpedia documentation](https://almond.stanford.edu/thingpedia/developers/thingpedia-nl-support.md)
 for a description of dataset files.
 
 The latest dataset file for the reference Thingpedia can be downloaded with:

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ semantic parsing code live in other repositories.
 
 ## Installation
 
-See [INSTALL.md]
+See [Install](INSTALL.md).
 
 ## License
 
 This package is covered by the GNU General Public License, version 3
-or any later version. See [LICENSE] for details.
+or any later version. See [LICENSE](LICENSE) for details.
 
 ## Reproducing the results of the paper
 
-To reproduce the machine learning results of the paper, see [doc/reproducing.md].
+To reproduce the machine learning results of the paper, see [Reproducing](doc/reproducing.md).
 
 ## Using Genie
 


### PR DESCRIPTION
The links for INSTALL.md, LICENSE and doc/reproducing.md are broken.
FIx README.md. 