### PR TITLE
Add Traditional Chinese in i18n

### DIFF
--- a/lib/i18n/index.js
+++ b/lib/i18n/index.js
@@ -25,7 +25,10 @@ module.exports = {
 
     // accept both BGP47 forms (either with Script code or with Country code)
     'zh-cn': require('./simplified-chinese'),
-    'zh-hans': require('./simplified-chinese')
+    'zh-hans': require('./simplified-chinese'),
+    
+    'zh-tw': require('./traditional-chinese'),
+    'zh-hant': require('./traditional-chinese')
 };
 Object.defineProperty(module.exports, 'get', {
     configurable: true,


### PR DESCRIPTION
Because our firstly translated dataset contains Traditional Chinese sentences, we also want Genie support `--locale=zh-tw` and `--locale=zh-hant`.